### PR TITLE
Update UnixClient.php

### DIFF
--- a/src/UnixClient.php
+++ b/src/UnixClient.php
@@ -21,7 +21,7 @@ class UnixClient
                 'package_max_length'    => 1024*1024
             ]
         );
-        $this->client->connect($unixSock,null,3);
+        $this->client->connect($unixSock,0,3);
     }
     function __destruct()
     {


### PR DESCRIPTION
[error]:Swoole\Coroutine\Client::connect(): Argument #2 ($port) must be of type int, string given at line:24